### PR TITLE
feat: added feh backend for setting wallpaper in i3 window managers

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -8,6 +8,7 @@ const (
 	Swww     BackendName = "swww"
 	Gnome    BackendName = "gnome"
 	Plasma   BackendName = "plasma"
+	Feh      BackendName = "feh"
 	MvpPaper BackendName = "mvppaper"
 )
 
@@ -21,6 +22,7 @@ var Backends = map[BackendName]Backend{
 	Swww:   &swwwBackend{},
 	Gnome:  &gnomeBackend{},
 	Plasma: &plasmaBackend{},
+	Feh:    &fehBackend{},
 }
 
 func GetAvailable() []string {

--- a/backends/feh.go
+++ b/backends/feh.go
@@ -1,0 +1,39 @@
+package backends
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/charmbracelet/log"
+)
+
+const FEH_EXEC_BIN = "/usr/bin/feh"
+
+type fehBackend struct{}
+
+func (b *fehBackend) Apply(buf bytes.Buffer) error {
+	name := fmt.Sprintf("walli-%d.jpg", time.Now().UnixMilli())
+	path := "/tmp/" + name
+
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("feh: could not write buffer to %s: %w", path, err)
+	}
+
+	return b.ApplyFile(path)
+}
+
+func (b *fehBackend) ApplyFile(filename string) error {
+	cmd := exec.Command(FEH_EXEC_BIN, "--bg-scale", filename)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("feh: failed to set wallpaper: %w", err)
+	}
+
+	log.Debug("feh set wallpaper to", filename)
+	return nil
+}


### PR DESCRIPTION
This pull request adds a new feh backend to support window managers like i3 that do not rely on full desktop environments such as GNOME or KDE.

### What’s added:

- A new fehBackend type implementing the Backend interface. 
-  Integration into Backends map for availability.
-  The backend writes the wallpaper buffer to /tmp and uses feh --bg-scale to apply it.

### Notes:

- Manually tested under i3 with feh installed.

Let me know if anything needs refactoring or if additional tests are required. Happy to iterate based on feedback.